### PR TITLE
fix url parsing to match http signign format

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -46,7 +46,8 @@ export class HttpSigning {
                 let value = config.headers?.hasOwnProperty(item) ? config.headers[item] : null;
 
                 if (item === '(request-target)') {
-                    value = config.method?.toLowerCase() + ' ' + config.url;
+                    const url = new URL(config.url as string);
+                    value = config.method?.toLowerCase() + ' ' + url.pathname + url.search;
                 } else if (item.toLowerCase() === 'date') {
                     value = date;
                 } else if (item.toLowerCase() === 'digest') {

--- a/index.ts
+++ b/index.ts
@@ -46,7 +46,7 @@ export class HttpSigning {
                 let value = config.headers?.hasOwnProperty(item) ? config.headers[item] : null;
 
                 if (item === '(request-target)') {
-                    value = config.method?.toLowerCase() + ' ' + (new URL(config.url as string)).pathname;
+                    value = config.method?.toLowerCase() + ' ' + config.url;
                 } else if (item.toLowerCase() === 'date') {
                     value = date;
                 } else if (item.toLowerCase() === 'digest') {


### PR DESCRIPTION
Current url parsing does not match http signing library parsing format, this fix aims to correct that.